### PR TITLE
fix: reject whitespace-only extensions in Source::fromBytes

### DIFF
--- a/src/Source.php
+++ b/src/Source.php
@@ -24,7 +24,7 @@ final readonly class Source
 
     public static function fromBytes(string $contents, string $extension): self
     {
-        $normalized = strtolower(ltrim($extension, '.'));
+        $normalized = strtolower(ltrim(trim($extension), '.'));
 
         if ($normalized === '') {
             throw new InvalidArgumentException('A non-empty file extension is required for byte sources so liteparse can detect the format.');

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -38,3 +38,11 @@ it('throws when the path is not readable', function (): void {
 it('rejects an empty extension for byte sources', function (): void {
     Source::fromBytes('data', '.');
 })->throws(InvalidArgumentException::class);
+
+it('rejects a whitespace-only extension for byte sources', function (): void {
+    Source::fromBytes('data', '   ');
+})->throws(InvalidArgumentException::class);
+
+it('rejects a tab-only extension for byte sources', function (): void {
+    Source::fromBytes('data', "\t");
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
ltrim only strips leading dots, so '   ' passed validation and created a temp file with spaces as the extension. Add trim() before ltrim() so whitespace-only inputs throw InvalidArgumentException like empty strings do.