### PR TITLE
fix: treat empty string as unset in BinaryResolver::resolve

### DIFF
--- a/src/Support/BinaryResolver.php
+++ b/src/Support/BinaryResolver.php
@@ -19,7 +19,7 @@ final readonly class BinaryResolver
 
     public function resolve(?string $explicit = null): string
     {
-        if ($explicit !== null) {
+        if ($explicit !== null && $explicit !== '') {
             return $explicit;
         }
 

--- a/tests/Unit/BinaryResolverTest.php
+++ b/tests/Unit/BinaryResolverTest.php
@@ -26,3 +26,7 @@ it('falls back to a PATH lookup', function (): void {
 it('throws when the binary cannot be resolved anywhere', function (): void {
     new BinaryResolver(new FakeExecutableFinder)->resolve();
 })->throws(BinaryNotFoundException::class);
+
+it('throws when an empty string is passed as the explicit path', function (): void {
+    new BinaryResolver(new FakeExecutableFinder)->resolve('');
+})->throws(BinaryNotFoundException::class);


### PR DESCRIPTION
Passing an empty string as the explicit path silently returned it, causing the process to fail with a cryptic OS error instead of a clean BinaryNotFoundException. Guard now treats '' the same as null.