### PR TITLE
fix: suppress OCR flags when OCR is disabled in parseArgv

### DIFF
--- a/src/PendingParse.php
+++ b/src/PendingParse.php
@@ -346,12 +346,12 @@ final class PendingParse
 
         if ($this->ocrDisabled) {
             $argv[] = '--no-ocr';
+        } else {
+            $argv = $this->appendFlag($argv, 'ocr-language', $this->ocrLanguage);
+            $argv = $this->appendFlag($argv, 'ocr-server-url', $this->ocrServerUrl);
+            $argv = $this->appendFlag($argv, 'tessdata-path', $this->tessdataPath);
+            $argv = $this->appendFlag($argv, 'num-workers', $this->workers);
         }
-
-        $argv = $this->appendFlag($argv, 'ocr-language', $this->ocrLanguage);
-        $argv = $this->appendFlag($argv, 'ocr-server-url', $this->ocrServerUrl);
-        $argv = $this->appendFlag($argv, 'tessdata-path', $this->tessdataPath);
-        $argv = $this->appendFlag($argv, 'num-workers', $this->workers);
         $argv = $this->appendFlag($argv, 'dpi', $this->dpi);
 
         if ($this->preserveSmallText) {

--- a/tests/Unit/PendingParseTest.php
+++ b/tests/Unit/PendingParseTest.php
@@ -223,6 +223,19 @@ it('maps withOcr parameters to flags and enables ocr', function (): void {
         ->and($command)->not->toContain('--no-ocr');
 });
 
+it('does not add ocr flags when ocr is disabled', function (): void {
+    $fake = new FakeProcessRunner(['--format text' => '']);
+
+    fakeParse($fake)->withOcr(language: 'eng', tessdataPath: '/usr/share/tessdata')->withoutOcr()->text();
+
+    $command = $fake->recordedCommands()[0];
+
+    expect($command)
+        ->toContain('--no-ocr')
+        ->and($command)->not->toContain('--ocr-language')
+        ->and($command)->not->toContain('--tessdata-path');
+});
+
 it('adds --preserve-small-text', function (): void {
     $fake = new FakeProcessRunner(['--format text' => '']);
 


### PR DESCRIPTION
OCR-related flags (--ocr-language, --ocr-server-url, --tessdata-path, --num-workers) were appended unconditionally, so a command could contain both --no-ocr and --ocr-language at the same time. Flags are now only added when OCR is enabled.