### PR TITLE
fix: reject empty and whitespace-only paths in Source::fromPath

### DIFF
--- a/src/Source.php
+++ b/src/Source.php
@@ -19,6 +19,10 @@ final readonly class Source
 
     public static function fromPath(string $path): self
     {
+        if (trim($path) === '') {
+            throw new InvalidArgumentException('A non-empty file path is required.');
+        }
+
         return new self(strtolower(pathinfo($path, PATHINFO_EXTENSION)), $path, null);
     }
 

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -39,6 +39,14 @@ it('rejects an empty extension for byte sources', function (): void {
     Source::fromBytes('data', '.');
 })->throws(InvalidArgumentException::class);
 
+it('rejects an empty path', function (): void {
+    Source::fromPath('');
+})->throws(InvalidArgumentException::class);
+
+it('rejects a whitespace-only path', function (): void {
+    Source::fromPath('   ');
+})->throws(InvalidArgumentException::class);
+
 it('rejects a whitespace-only extension for byte sources', function (): void {
     Source::fromBytes('data', '   ');
 })->throws(InvalidArgumentException::class);


### PR DESCRIPTION
Passing an empty or whitespace-only string silently created a Source with no usable path, leading to a cryptic OS-level error later in the process. Guard now throws InvalidArgumentException immediately.

## What does this PR do?
Source::fromPath('') and Source::fromPath('   ') silently accepted empty/whitespace paths, storing them internally and only failing later with a cryptic OS-level error when the process tried to open the file. This adds an upfront guard that throws InvalidArgumentException immediately with a clear message.

## Type of change
- [X] Bug fix

## Checklist
- [X] Tests added or updated
- [X] `composer lint` passes
- [X] `composer test` passes
