### PR TITLE
fix: throw FilesystemException when screenshot directory does not exist

### DIFF
--- a/src/Exceptions/FilesystemException.php
+++ b/src/Exceptions/FilesystemException.php
@@ -10,4 +10,9 @@ final class FilesystemException extends ParselException
     {
         return new self(sprintf('Unable to write to "%s".', $path));
     }
+
+    public static function directoryNotFound(string $path): self
+    {
+        return new self(sprintf('Screenshot directory "%s" does not exist.', $path));
+    }
 }

--- a/src/PendingParse.php
+++ b/src/PendingParse.php
@@ -13,6 +13,7 @@ use Shipfastlabs\Parsel\Contracts\ProcessRunner;
 use Shipfastlabs\Parsel\Data\Document;
 use Shipfastlabs\Parsel\Data\Page;
 use Shipfastlabs\Parsel\Enums\OutputFormat;
+use Shipfastlabs\Parsel\Exceptions\FilesystemException;
 use Shipfastlabs\Parsel\Exceptions\InvalidOutputException;
 use Shipfastlabs\Parsel\Exceptions\ParseFailedException;
 use Shipfastlabs\Parsel\Support\BinaryResolver;
@@ -202,6 +203,10 @@ final class PendingParse
      */
     public function screenshots(string $directory): array
     {
+        if (! $this->files->exists($directory)) {
+            throw FilesystemException::directoryNotFound($directory);
+        }
+
         $this->runFor(fn (string $binary, string $file): array => $this->screenshotArgv($binary, $file, $directory));
 
         return $this->files->files($directory);

--- a/tests/Unit/PendingParseTest.php
+++ b/tests/Unit/PendingParseTest.php
@@ -7,6 +7,7 @@ use Shipfastlabs\Parsel\Contracts\ProcessRunner;
 use Shipfastlabs\Parsel\Data\Document;
 use Shipfastlabs\Parsel\Data\Page;
 use Shipfastlabs\Parsel\Exceptions\BinaryNotFoundException;
+use Shipfastlabs\Parsel\Exceptions\FilesystemException;
 use Shipfastlabs\Parsel\Exceptions\InvalidOutputException;
 use Shipfastlabs\Parsel\Exceptions\ParseFailedException;
 use Shipfastlabs\Parsel\Exceptions\SourceNotFoundException;
@@ -110,6 +111,12 @@ it('throws when the streaming process fails', function (): void {
 
     iterator_to_array($parse->lazyPages());
 })->throws(ParseFailedException::class);
+
+it('throws when the screenshot directory does not exist', function (): void {
+    Parsel::fake(['screenshot' => '']);
+
+    Parsel::file(fixture('sample.pdf'))->screenshots('/non/existent/directory');
+})->throws(FilesystemException::class);
 
 it('builds the screenshot argv including extra options', function (): void {
     $fake = new FakeProcessRunner(['screenshot' => '']);


### PR DESCRIPTION
## What does this PR do?

`screenshots()` silently returned an empty array when the output directory did not exist, making it impossible to distinguish from a successful run with no output. This adds an upfront guard that throws `FilesystemException::directoryNotFound()` immediately before invoking the binary.

Also adds a `directoryNotFound` named constructor to `FilesystemException` following the existing pattern.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated
- [x] `composer lint` passes
- [x] `composer test` passes