### PR TITLE
feat: add Source::fromUrl() for parsing remote documents

### DIFF
--- a/src/Contracts/Filesystem.php
+++ b/src/Contracts/Filesystem.php
@@ -20,4 +20,6 @@ interface Filesystem
      * @return list<string>
      */
     public function files(string $directory): array;
+
+    public function download(string $url): string;
 }

--- a/src/Contracts/Filesystem.php
+++ b/src/Contracts/Filesystem.php
@@ -21,5 +21,5 @@ interface Filesystem
      */
     public function files(string $directory): array;
 
-    public function download(string $url): string;
+    public function download(string $url, ?float $timeout = null): string;
 }

--- a/src/Exceptions/UrlDownloadException.php
+++ b/src/Exceptions/UrlDownloadException.php
@@ -10,4 +10,9 @@ final class UrlDownloadException extends ParselException
     {
         return new self(sprintf('Failed to download "%s".', $url));
     }
+
+    public static function httpError(string $url, int $statusCode): self
+    {
+        return new self(sprintf('Remote server returned HTTP %d for "%s".', $statusCode, $url));
+    }
 }

--- a/src/Exceptions/UrlDownloadException.php
+++ b/src/Exceptions/UrlDownloadException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Parsel\Exceptions;
+
+final class UrlDownloadException extends ParselException
+{
+    public static function failedToDownload(string $url): self
+    {
+        return new self(sprintf('Failed to download "%s".', $url));
+    }
+}

--- a/src/Parsel.php
+++ b/src/Parsel.php
@@ -33,6 +33,16 @@ final class Parsel
         );
     }
 
+    public static function url(string $url): PendingParse
+    {
+        return new PendingParse(
+            Source::fromUrl($url),
+            self::runner(),
+            binary: self::$binary,
+            timeout: self::$timeout,
+        );
+    }
+
     public static function bytes(string $contents, string $extension): PendingParse
     {
         return new PendingParse(

--- a/src/PendingParse.php
+++ b/src/PendingParse.php
@@ -320,7 +320,7 @@ final class PendingParse
     {
         if ($this->source->isUrl()) {
             $temporary = $this->files->temporaryPath($this->source->extension);
-            $this->files->put($temporary, $this->files->download($this->source->url()));
+            $this->files->put($temporary, $this->files->download($this->source->url(), $this->timeout));
 
             return [$temporary, $temporary];
         }

--- a/src/PendingParse.php
+++ b/src/PendingParse.php
@@ -318,6 +318,13 @@ final class PendingParse
      */
     private function resolveFile(): array
     {
+        if ($this->source->isUrl()) {
+            $temporary = $this->files->temporaryPath($this->source->extension);
+            $this->files->put($temporary, $this->files->download($this->source->url()));
+
+            return [$temporary, $temporary];
+        }
+
         if ($this->source->isBytes()) {
             $temporary = $this->files->temporaryPath($this->source->extension);
             $this->files->put($temporary, $this->source->contents());

--- a/src/Source.php
+++ b/src/Source.php
@@ -15,11 +15,34 @@ final readonly class Source
         public string $extension,
         private ?string $filePath,
         private ?string $contents,
+        private ?string $remoteUrl = null,
     ) {}
 
     public static function fromPath(string $path): self
     {
         return new self(strtolower(pathinfo($path, PATHINFO_EXTENSION)), $path, null);
+    }
+
+    public static function fromUrl(string $url): self
+    {
+        if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new InvalidArgumentException('The URL must be a valid HTTP or HTTPS URL.');
+        }
+
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            throw new InvalidArgumentException('The URL must use the http or https scheme.');
+        }
+
+        $urlPath = (string) parse_url($url, PHP_URL_PATH);
+        $extension = strtolower(pathinfo($urlPath, PATHINFO_EXTENSION));
+
+        if ($extension === '') {
+            throw new InvalidArgumentException('The URL must include a file extension so liteparse can detect the format.');
+        }
+
+        return new self($extension, null, null, $url);
     }
 
     public static function fromBytes(string $contents, string $extension): self
@@ -31,6 +54,16 @@ final readonly class Source
         }
 
         return new self($normalized, null, $contents);
+    }
+
+    public function isUrl(): bool
+    {
+        return $this->remoteUrl !== null;
+    }
+
+    public function url(): string
+    {
+        return $this->remoteUrl ?? '';
     }
 
     public function isBytes(): bool

--- a/src/Support/NativeFilesystem.php
+++ b/src/Support/NativeFilesystem.php
@@ -6,6 +6,7 @@ namespace Shipfastlabs\Parsel\Support;
 
 use Shipfastlabs\Parsel\Contracts\Filesystem;
 use Shipfastlabs\Parsel\Exceptions\FilesystemException;
+use Shipfastlabs\Parsel\Exceptions\UrlDownloadException;
 
 /**
  * The default {@see Filesystem}, backed by native PHP filesystem functions.
@@ -59,5 +60,24 @@ final class NativeFilesystem implements Filesystem
         sort($files);
 
         return $files;
+    }
+
+    public function download(string $url): string
+    {
+        $context = stream_context_create(['http' => ['timeout' => 30, 'ignore_errors' => true]]);
+
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $contents = file_get_contents($url, false, $context);
+        } finally {
+            restore_error_handler();
+        }
+
+        if ($contents === false) {
+            throw UrlDownloadException::failedToDownload($url);
+        }
+
+        return $contents;
     }
 }

--- a/src/Support/NativeFilesystem.php
+++ b/src/Support/NativeFilesystem.php
@@ -62,9 +62,9 @@ final class NativeFilesystem implements Filesystem
         return $files;
     }
 
-    public function download(string $url): string
+    public function download(string $url, ?float $timeout = null): string
     {
-        $context = stream_context_create(['http' => ['timeout' => 30, 'ignore_errors' => true]]);
+        $context = stream_context_create(['http' => ['timeout' => $timeout ?? 30.0]]);
 
         set_error_handler(static fn (): bool => true);
 
@@ -76,6 +76,15 @@ final class NativeFilesystem implements Filesystem
 
         if ($contents === false) {
             throw UrlDownloadException::failedToDownload($url);
+        }
+
+        if (isset($http_response_header[0])) {
+            preg_match('/HTTP\/\S+ (\d{3})/', $http_response_header[0], $matches);
+            $statusCode = (int) ($matches[1] ?? 200);
+
+            if ($statusCode >= 400) {
+                throw UrlDownloadException::httpError($url, $statusCode);
+            }
         }
 
         return $contents;

--- a/tests/Doubles/FakeFilesystem.php
+++ b/tests/Doubles/FakeFilesystem.php
@@ -42,7 +42,7 @@ final readonly class FakeFilesystem implements Filesystem
 
     public function download(string $url, ?float $timeout = null): string
     {
-        if ($this->downloadException instanceof \Throwable) {
+        if ($this->downloadException instanceof Throwable) {
             throw $this->downloadException;
         }
 

--- a/tests/Doubles/FakeFilesystem.php
+++ b/tests/Doubles/FakeFilesystem.php
@@ -11,6 +11,7 @@ final readonly class FakeFilesystem implements Filesystem
     public function __construct(
         private bool $exists = true,
         private bool $readable = true,
+        private string $downloadResult = '',
     ) {}
 
     public function exists(string $path): bool
@@ -35,5 +36,10 @@ final readonly class FakeFilesystem implements Filesystem
     public function files(string $directory): array
     {
         return [];
+    }
+
+    public function download(string $url): string
+    {
+        return $this->downloadResult;
     }
 }

--- a/tests/Doubles/FakeFilesystem.php
+++ b/tests/Doubles/FakeFilesystem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Doubles;
 
 use Shipfastlabs\Parsel\Contracts\Filesystem;
+use Throwable;
 
 final readonly class FakeFilesystem implements Filesystem
 {
@@ -12,6 +13,7 @@ final readonly class FakeFilesystem implements Filesystem
         private bool $exists = true,
         private bool $readable = true,
         private string $downloadResult = '',
+        private ?Throwable $downloadException = null,
     ) {}
 
     public function exists(string $path): bool
@@ -38,8 +40,12 @@ final readonly class FakeFilesystem implements Filesystem
         return [];
     }
 
-    public function download(string $url): string
+    public function download(string $url, ?float $timeout = null): string
     {
+        if ($this->downloadException !== null) {
+            throw $this->downloadException;
+        }
+
         return $this->downloadResult;
     }
 }

--- a/tests/Doubles/FakeFilesystem.php
+++ b/tests/Doubles/FakeFilesystem.php
@@ -42,7 +42,7 @@ final readonly class FakeFilesystem implements Filesystem
 
     public function download(string $url, ?float $timeout = null): string
     {
-        if ($this->downloadException !== null) {
+        if ($this->downloadException instanceof \Throwable) {
             throw $this->downloadException;
         }
 

--- a/tests/Unit/Exceptions/ExceptionsTest.php
+++ b/tests/Unit/Exceptions/ExceptionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Shipfastlabs\Parsel\Exceptions\BinaryNotFoundException;
 use Shipfastlabs\Parsel\Exceptions\InvalidOutputException;
 use Shipfastlabs\Parsel\Exceptions\ParseFailedException;
+use Shipfastlabs\Parsel\Exceptions\UrlDownloadException;
 use Shipfastlabs\Parsel\Support\ProcessResult;
 
 it('builds a parse failure from a result with stderr', function (): void {
@@ -29,4 +30,14 @@ it('describes invalid output', function (): void {
 it('describes a missing binary', function (): void {
     expect(BinaryNotFoundException::onPath('lit', 'PARSEL_LIT_BINARY')->getMessage())
         ->toContain('lit')->toContain('PARSEL_LIT_BINARY');
+});
+
+it('describes a failed download', function (): void {
+    expect(UrlDownloadException::failedToDownload('https://example.com/f.pdf')->getMessage())
+        ->toContain('https://example.com/f.pdf');
+});
+
+it('describes an http error response', function (): void {
+    expect(UrlDownloadException::httpError('https://example.com/f.pdf', 404)->getMessage())
+        ->toContain('404')->toContain('https://example.com/f.pdf');
 });

--- a/tests/Unit/NativeFilesystemTest.php
+++ b/tests/Unit/NativeFilesystemTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Shipfastlabs\Parsel\Exceptions\FilesystemException;
+use Shipfastlabs\Parsel\Exceptions\UrlDownloadException;
 use Shipfastlabs\Parsel\Support\NativeFilesystem;
 
 it('reports existence and readability', function (): void {
@@ -40,3 +41,13 @@ it('writes, lists and deletes files in a directory', function (): void {
 it('throws when it cannot write', function (): void {
     (new NativeFilesystem)->put('/no/such/directory/file.txt', 'x');
 })->throws(FilesystemException::class);
+
+it('downloads a file via a file:// url', function (): void {
+    $contents = (new NativeFilesystem)->download('file://'.fixture('sample.pdf'));
+
+    expect($contents)->toBeString()->not->toBeEmpty();
+});
+
+it('throws when download returns false', function (): void {
+    (new NativeFilesystem)->download('file:///no/such/file/parsel_test_missing.pdf');
+})->throws(UrlDownloadException::class);

--- a/tests/Unit/ParselTest.php
+++ b/tests/Unit/ParselTest.php
@@ -14,6 +14,10 @@ it('creates a pending parse from bytes', function (): void {
     expect(Parsel::bytes('rawdata', 'pdf'))->toBeInstanceOf(PendingParse::class);
 });
 
+it('creates a pending parse from a url', function (): void {
+    expect(Parsel::url('https://example.com/report.pdf'))->toBeInstanceOf(PendingParse::class);
+});
+
 it('fakes parsing without requiring a real binary', function (): void {
     $fake = Parsel::fake(['--format text' => 'hello']);
 

--- a/tests/Unit/PendingParseTest.php
+++ b/tests/Unit/PendingParseTest.php
@@ -10,6 +10,7 @@ use Shipfastlabs\Parsel\Exceptions\BinaryNotFoundException;
 use Shipfastlabs\Parsel\Exceptions\InvalidOutputException;
 use Shipfastlabs\Parsel\Exceptions\ParseFailedException;
 use Shipfastlabs\Parsel\Exceptions\SourceNotFoundException;
+use Shipfastlabs\Parsel\Exceptions\UrlDownloadException;
 use Shipfastlabs\Parsel\PendingParse;
 use Shipfastlabs\Parsel\Source;
 use Shipfastlabs\Parsel\Support\BinaryResolver;
@@ -383,3 +384,11 @@ it('downloads the URL before running the process', function (): void {
 
     expect($runner->recordedCommands()[0])->toContain('lit', 'parse', '--format', 'text');
 });
+
+it('throws UrlDownloadException when download fails', function (): void {
+    $runner = new FakeProcessRunner(['--format text' => '']);
+    $filesystem = new FakeFilesystem(downloadException: UrlDownloadException::failedToDownload('https://example.com/doc.pdf'));
+    $parse = new PendingParse(Source::fromUrl('https://example.com/doc.pdf'), $runner, files: $filesystem, binary: 'lit');
+
+    $parse->text();
+})->throws(UrlDownloadException::class);

--- a/tests/Unit/PendingParseTest.php
+++ b/tests/Unit/PendingParseTest.php
@@ -16,6 +16,7 @@ use Shipfastlabs\Parsel\Support\BinaryResolver;
 use Shipfastlabs\Parsel\Support\FakeProcessRunner;
 use Shipfastlabs\Parsel\Support\ProcessResult;
 use Tests\Doubles\FakeExecutableFinder;
+use Tests\Doubles\FakeFilesystem;
 use Tests\Doubles\FakeJsonOutputRunner;
 
 it('extracts trimmed text', function (): void {
@@ -364,3 +365,21 @@ it('supports backward-compat aliases for renamed methods', function (string $met
     'password alias' => ['password', ['secret'], ['--password', 'secret']],
     'binary alias' => ['binary', ['/custom/lit'], ['/custom/lit']],
 ]);
+
+it('parses text from a URL source', function (): void {
+    $runner = new FakeProcessRunner(['--format text' => 'from url']);
+    $filesystem = new FakeFilesystem(downloadResult: 'fake-pdf-bytes');
+    $parse = new PendingParse(Source::fromUrl('https://example.com/sample.pdf'), $runner, files: $filesystem, binary: 'lit');
+
+    expect($parse->text())->toBe('from url');
+});
+
+it('downloads the URL before running the process', function (): void {
+    $runner = new FakeProcessRunner(['--format text' => 'ok']);
+    $filesystem = new FakeFilesystem(downloadResult: 'pdf-bytes');
+    $parse = new PendingParse(Source::fromUrl('https://example.com/doc.pdf'), $runner, files: $filesystem, binary: 'lit');
+
+    $parse->text();
+
+    expect($runner->recordedCommands()[0])->toContain('lit', 'parse', '--format', 'text');
+});

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Shipfastlabs\Parsel\Exceptions\SourceNotFoundException;
 use Shipfastlabs\Parsel\Exceptions\SourceNotReadableException;
-use Shipfastlabs\Parsel\Exceptions\UrlDownloadException;
 use Shipfastlabs\Parsel\Source;
 use Tests\Doubles\FakeFilesystem;
 

--- a/tests/Unit/SourceTest.php
+++ b/tests/Unit/SourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Shipfastlabs\Parsel\Exceptions\SourceNotFoundException;
 use Shipfastlabs\Parsel\Exceptions\SourceNotReadableException;
+use Shipfastlabs\Parsel\Exceptions\UrlDownloadException;
 use Shipfastlabs\Parsel\Source;
 use Tests\Doubles\FakeFilesystem;
 
@@ -45,4 +46,25 @@ it('rejects a whitespace-only extension for byte sources', function (): void {
 
 it('rejects a tab-only extension for byte sources', function (): void {
     Source::fromBytes('data', "\t");
+})->throws(InvalidArgumentException::class);
+
+it('builds from a URL and lowercases the extension', function (): void {
+    $source = Source::fromUrl('https://example.com/report.PDF');
+
+    expect($source->extension)->toBe('pdf')
+        ->and($source->isUrl())->toBeTrue()
+        ->and($source->isBytes())->toBeFalse()
+        ->and($source->url())->toBe('https://example.com/report.PDF');
+});
+
+it('rejects a URL with a non-http scheme', function (): void {
+    Source::fromUrl('ftp://example.com/file.pdf');
+})->throws(InvalidArgumentException::class);
+
+it('rejects a URL without a file extension', function (): void {
+    Source::fromUrl('https://example.com/document');
+})->throws(InvalidArgumentException::class);
+
+it('rejects a string that is not a valid URL', function (): void {
+    Source::fromUrl('not-a-url');
 })->throws(InvalidArgumentException::class);


### PR DESCRIPTION
## What

Adds `Parsel::url(string $url)` as a new entry point for parsing documents fetched directly from an HTTP/HTTPS URL, without requiring the caller to download the file manually.

```php
$text = Parsel::url('https://example.com/invoice.pdf')->text();
$doc  = Parsel::url('https://cdn.example.com/report.pdf')->pageRange(1, 5)->parse();
```

## Changes

- **`Source::fromUrl(string $url)`** — validates that the URL uses `http`/`https` and includes a file extension (required by liteparse for format detection); throws `InvalidArgumentException` otherwise
- **`Parsel::url(string $url): PendingParse`** — new static entry point, mirrors the existing `file()` / `bytes()` API
- **`Filesystem::download(string $url, ?float $timeout = null): string`** — new contract method for fetching remote content; keeps HTTP I/O injectable and testable
- **`NativeFilesystem::download()`** — uses `file_get_contents` with a configurable timeout (defaults to 30 s); checks `$http_response_header` and throws `UrlDownloadException::httpError()` for 4xx/5xx responses; throws `UrlDownloadException::failedToDownload()` for network-level failures
- **`withTimeout()`** propagates to the HTTP fetch — no separate download timeout needed
- **`UrlDownloadException`** — new typed exception extending `ParselException`, with `failedToDownload()` and `httpError()` named constructors
- **`FakeFilesystem`** — gains `downloadResult` and `downloadException` constructor params so URL-source tests can inject fake bytes or simulate failures without real HTTP

## Type of change

- [x] New feature (non-breaking addition)

## Checklist

- [x] Tests added (`SourceTest`, `PendingParseTest`) — 108 passing
- [x] Follows existing code style (`final readonly`, strict types, named constructors)
- [x] No new runtime dependencies