### PR TITLE
fix: support both camelCase and snake_case keys from liteparse binary

### DIFF
--- a/src/Data/Cast.php
+++ b/src/Data/Cast.php
@@ -23,4 +23,19 @@ final class Cast
     {
         return is_numeric($value) ? (float) $value : 0.0;
     }
+
+    /**
+     * @param  array<string, mixed>  $raw
+     * @param  list<string>  $keys
+     */
+    public static function pick(array $raw, array $keys): mixed
+    {
+        foreach ($keys as $key) {
+            if (isset($raw[$key])) {
+                return $raw[$key];
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Data/Page.php
+++ b/src/Data/Page.php
@@ -22,7 +22,7 @@ final readonly class Page
      */
     public static function fromArray(array $raw): self
     {
-        $rawItems = $raw['textItems'] ?? [];
+        $rawItems = $raw['textItems'] ?? $raw['text_items'] ?? [];
         $items = [];
 
         if (is_array($rawItems)) {

--- a/src/Data/Page.php
+++ b/src/Data/Page.php
@@ -22,7 +22,7 @@ final readonly class Page
      */
     public static function fromArray(array $raw): self
     {
-        $rawItems = $raw['text_items'] ?? [];
+        $rawItems = $raw['textItems'] ?? [];
         $items = [];
 
         if (is_array($rawItems)) {

--- a/src/Data/Page.php
+++ b/src/Data/Page.php
@@ -22,7 +22,7 @@ final readonly class Page
      */
     public static function fromArray(array $raw): self
     {
-        $rawItems = $raw['textItems'] ?? $raw['text_items'] ?? [];
+        $rawItems = Cast::pick($raw, ['textItems', 'text_items']) ?? [];
         $items = [];
 
         if (is_array($rawItems)) {

--- a/src/Data/TextItem.php
+++ b/src/Data/TextItem.php
@@ -29,8 +29,8 @@ final readonly class TextItem
             width: Cast::float($raw['width'] ?? 0),
             height: Cast::float($raw['height'] ?? 0),
             confidence: isset($raw['confidence']) ? Cast::float($raw['confidence']) : null,
-            fontName: isset($raw['font_name']) ? Cast::str($raw['font_name']) : null,
-            fontSize: isset($raw['font_size']) ? Cast::float($raw['font_size']) : null,
+            fontName: isset($raw['fontName']) ? Cast::str($raw['fontName']) : null,
+            fontSize: isset($raw['fontSize']) ? Cast::float($raw['fontSize']) : null,
         );
     }
 

--- a/src/Data/TextItem.php
+++ b/src/Data/TextItem.php
@@ -22,6 +22,9 @@ final readonly class TextItem
      */
     public static function fromArray(array $raw): self
     {
+        $fontName = Cast::pick($raw, ['fontName', 'font_name']);
+        $fontSize = Cast::pick($raw, ['fontSize', 'font_size']);
+
         return new self(
             text: Cast::str($raw['text'] ?? ''),
             x: Cast::float($raw['x'] ?? 0),
@@ -29,8 +32,8 @@ final readonly class TextItem
             width: Cast::float($raw['width'] ?? 0),
             height: Cast::float($raw['height'] ?? 0),
             confidence: isset($raw['confidence']) ? Cast::float($raw['confidence']) : null,
-            fontName: isset($raw['fontName']) ? Cast::str($raw['fontName']) : (isset($raw['font_name']) ? Cast::str($raw['font_name']) : null),
-            fontSize: isset($raw['fontSize']) ? Cast::float($raw['fontSize']) : (isset($raw['font_size']) ? Cast::float($raw['font_size']) : null),
+            fontName: $fontName !== null ? Cast::str($fontName) : null,
+            fontSize: $fontSize !== null ? Cast::float($fontSize) : null,
         );
     }
 

--- a/src/Data/TextItem.php
+++ b/src/Data/TextItem.php
@@ -29,8 +29,8 @@ final readonly class TextItem
             width: Cast::float($raw['width'] ?? 0),
             height: Cast::float($raw['height'] ?? 0),
             confidence: isset($raw['confidence']) ? Cast::float($raw['confidence']) : null,
-            fontName: isset($raw['fontName']) ? Cast::str($raw['fontName']) : null,
-            fontSize: isset($raw['fontSize']) ? Cast::float($raw['fontSize']) : null,
+            fontName: isset($raw['fontName']) ? Cast::str($raw['fontName']) : (isset($raw['font_name']) ? Cast::str($raw['font_name']) : null),
+            fontSize: isset($raw['fontSize']) ? Cast::float($raw['fontSize']) : (isset($raw['font_size']) ? Cast::float($raw['font_size']) : null),
         );
     }
 

--- a/tests/Fixtures/liteparse-output-snake.json
+++ b/tests/Fixtures/liteparse-output-snake.json
@@ -1,0 +1,50 @@
+{
+  "pages": [
+    {
+      "page": 1,
+      "width": 612.0,
+      "height": 792.0,
+      "text": "UNITED STATES\nForm 10-K",
+      "text_items": [
+        {
+          "text": "UNITED STATES",
+          "x": 254.38,
+          "y": 58.106018,
+          "width": 103.0,
+          "height": 13.0,
+          "font_name": "AAAGYH+HelveticaLTStd-Bold",
+          "font_size": 13.0,
+          "confidence": 1.0
+        },
+        {
+          "text": "Form 10-K",
+          "x": 100.0,
+          "y": 80.0,
+          "width": 60.0,
+          "height": 12.0,
+          "font_name": "AAAGYH+HelveticaLTStd",
+          "font_size": 12.0,
+          "confidence": 1.0
+        }
+      ]
+    },
+    {
+      "page": 2,
+      "width": 612.0,
+      "height": 792.0,
+      "text": "Page two body text",
+      "text_items": [
+        {
+          "text": "Page two body text",
+          "x": 72.0,
+          "y": 100.0,
+          "width": 120.0,
+          "height": 11.0,
+          "font_name": "TimesNewRoman",
+          "font_size": 11.0,
+          "confidence": 0.98
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Fixtures/liteparse-output.json
+++ b/tests/Fixtures/liteparse-output.json
@@ -5,15 +5,15 @@
       "width": 612.0,
       "height": 792.0,
       "text": "UNITED STATES\nForm 10-K",
-      "text_items": [
+      "textItems": [
         {
           "text": "UNITED STATES",
           "x": 254.38,
           "y": 58.106018,
           "width": 103.0,
           "height": 13.0,
-          "font_name": "AAAGYH+HelveticaLTStd-Bold",
-          "font_size": 13.0,
+          "fontName": "AAAGYH+HelveticaLTStd-Bold",
+          "fontSize": 13.0,
           "confidence": 1.0
         },
         {
@@ -22,8 +22,8 @@
           "y": 80.0,
           "width": 60.0,
           "height": 12.0,
-          "font_name": "AAAGYH+HelveticaLTStd",
-          "font_size": 12.0,
+          "fontName": "AAAGYH+HelveticaLTStd",
+          "fontSize": 12.0,
           "confidence": 1.0
         }
       ]
@@ -33,15 +33,15 @@
       "width": 612.0,
       "height": 792.0,
       "text": "Page two body text",
-      "text_items": [
+      "textItems": [
         {
           "text": "Page two body text",
           "x": 72.0,
           "y": 100.0,
           "width": 120.0,
           "height": 11.0,
-          "font_name": "TimesNewRoman",
-          "font_size": 11.0,
+          "fontName": "TimesNewRoman",
+          "fontSize": 11.0,
           "confidence": 0.98
         }
       ]

--- a/tests/Unit/Dtos/DocumentTest.php
+++ b/tests/Unit/Dtos/DocumentTest.php
@@ -46,9 +46,36 @@ it('serializes to an array', function (): void {
         ->and($doc->toArray()['pages'])->toHaveCount(1);
 });
 
+it('maps real liteparse snake_case json into a document', function (): void {
+    /** @var array<string, mixed> $decoded */
+    $decoded = json_decode(fixtureContents('liteparse-output-snake.json'), true);
+
+    $doc = Document::fromLiteParseJson($decoded);
+
+    expect($doc->pageCount())->toBe(2)
+        ->and($doc->pages[0]->number)->toBe(1)
+        ->and($doc->pages[0]->items)->toHaveCount(2)
+        ->and($doc->pages[0]->items[0]->text)->toBe('UNITED STATES')
+        ->and($doc->pages[0]->items[0]->fontName)->toBe('AAAGYH+HelveticaLTStd-Bold')
+        ->and($doc->text)->toBe("UNITED STATES\nForm 10-K\n\nPage two body text");
+});
+
 it('reshapes liteparse json to an array without building the object graph', function (): void {
     /** @var array<string, mixed> $decoded */
     $decoded = json_decode(fixtureContents('liteparse-output.json'), true);
+
+    $array = Document::arrayFromLiteParseJson($decoded);
+
+    expect($array['pages'])->toHaveCount(2)
+        ->and($array['pages'][0])->toHaveKeys(['number', 'width', 'height', 'text', 'items'])
+        ->and($array['pages'][0]['items'])->toHaveCount(2)
+        ->and($array['text'])->toBe("UNITED STATES\nForm 10-K\n\nPage two body text")
+        ->and($array['metadata'])->toBe([]);
+});
+
+it('reshapes liteparse snake_case json to an array without building the object graph', function (): void {
+    /** @var array<string, mixed> $decoded */
+    $decoded = json_decode(fixtureContents('liteparse-output-snake.json'), true);
 
     $array = Document::arrayFromLiteParseJson($decoded);
 

--- a/tests/Unit/Dtos/PageTest.php
+++ b/tests/Unit/Dtos/PageTest.php
@@ -37,7 +37,7 @@ it('falls back to snake_case text_items key', function (): void {
     ]);
 
     expect($page->items)->toHaveCount(1)
-        ->and($page->items[0])->toBeInstanceOf(\Shipfastlabs\Parsel\Data\TextItem::class);
+        ->and($page->items[0])->toBeInstanceOf(TextItem::class);
 });
 
 it('skips text items that are not arrays', function (): void {

--- a/tests/Unit/Dtos/PageTest.php
+++ b/tests/Unit/Dtos/PageTest.php
@@ -11,7 +11,7 @@ it('maps a page with positioned text items', function (): void {
         'width' => 612.0,
         'height' => 792.0,
         'text' => 'hello',
-        'text_items' => [
+        'textItems' => [
             ['text' => 'hello', 'x' => 1, 'y' => 2, 'width' => 3, 'height' => 4],
         ],
     ]);
@@ -24,21 +24,21 @@ it('maps a page with positioned text items', function (): void {
         ->and($page->items[0])->toBeInstanceOf(TextItem::class);
 });
 
-it('tolerates a non-array text_items value', function (): void {
-    expect(Page::fromArray(['page' => 1, 'text_items' => 'nope'])->items)->toBe([]);
+it('tolerates a non-array textItems value', function (): void {
+    expect(Page::fromArray(['page' => 1, 'textItems' => 'nope'])->items)->toBe([]);
 });
 
 it('skips text items that are not arrays', function (): void {
     $page = Page::fromArray([
         'page' => 1,
-        'text_items' => ['bad', ['text' => 'a', 'x' => 1, 'y' => 1, 'width' => 1, 'height' => 1]],
+        'textItems' => ['bad', ['text' => 'a', 'x' => 1, 'y' => 1, 'width' => 1, 'height' => 1]],
     ]);
 
     expect($page->items)->toHaveCount(1);
 });
 
 it('serializes to an array', function (): void {
-    $page = Page::fromArray(['page' => 1, 'width' => 1.0, 'height' => 2.0, 'text' => 't', 'text_items' => []]);
+    $page = Page::fromArray(['page' => 1, 'width' => 1.0, 'height' => 2.0, 'text' => 't', 'textItems' => []]);
 
     expect($page->toArray())->toBe([
         'number' => 1,

--- a/tests/Unit/Dtos/PageTest.php
+++ b/tests/Unit/Dtos/PageTest.php
@@ -28,6 +28,18 @@ it('tolerates a non-array textItems value', function (): void {
     expect(Page::fromArray(['page' => 1, 'textItems' => 'nope'])->items)->toBe([]);
 });
 
+it('falls back to snake_case text_items key', function (): void {
+    $page = Page::fromArray([
+        'page' => 1,
+        'text_items' => [
+            ['text' => 'hello', 'x' => 1, 'y' => 2, 'width' => 3, 'height' => 4],
+        ],
+    ]);
+
+    expect($page->items)->toHaveCount(1)
+        ->and($page->items[0])->toBeInstanceOf(\Shipfastlabs\Parsel\Data\TextItem::class);
+});
+
 it('skips text items that are not arrays', function (): void {
     $page = Page::fromArray([
         'page' => 1,

--- a/tests/Unit/Dtos/TextItemTest.php
+++ b/tests/Unit/Dtos/TextItemTest.php
@@ -44,3 +44,15 @@ it('defaults optional fields to null when absent', function (): void {
         ->and($item->fontName)->toBeNull()
         ->and($item->fontSize)->toBeNull();
 });
+
+it('falls back to snake_case font keys', function (): void {
+    $item = TextItem::fromArray([
+        'text' => 'Hi',
+        'x' => 0, 'y' => 0, 'width' => 0, 'height' => 0,
+        'font_name' => 'Helvetica',
+        'font_size' => 10.0,
+    ]);
+
+    expect($item->fontName)->toBe('Helvetica')
+        ->and($item->fontSize)->toBe(10.0);
+});

--- a/tests/Unit/Dtos/TextItemTest.php
+++ b/tests/Unit/Dtos/TextItemTest.php
@@ -12,8 +12,8 @@ it('maps a full raw item including font and confidence', function (): void {
         'width' => 3.0,
         'height' => 4.0,
         'confidence' => 0.9,
-        'font_name' => 'Arial',
-        'font_size' => 12.0,
+        'fontName' => 'Arial',
+        'fontSize' => 12.0,
     ]);
 
     expect($item->text)->toBe('Hi')

--- a/tests/Unit/PendingParseTest.php
+++ b/tests/Unit/PendingParseTest.php
@@ -46,6 +46,18 @@ it('parses into a structured document', function (): void {
         ->and($document->pages[0]->items[0]->text)->toBe('UNITED STATES');
 });
 
+it('populates text items and font data from camelCase binary output', function (): void {
+    Parsel::fake(['--format json' => fixtureContents('liteparse-output.json')]);
+
+    $document = Parsel::file(fixture('sample.pdf'))->parse();
+    $item = $document->pages[0]->items[0];
+
+    expect($document->pages[0]->items)->not->toBeEmpty()
+        ->and($item->text)->toBe('UNITED STATES')
+        ->and($item->fontName)->toBe('AAAGYH+HelveticaLTStd-Bold')
+        ->and($item->fontSize)->toBe(13.0);
+});
+
 it('returns the document as an array', function (): void {
     Parsel::fake(['--format json' => fixtureContents('liteparse-output.json')]);
 
@@ -57,7 +69,7 @@ it('saves liteparse json verbatim by extension', function (): void {
     $out = sys_get_temp_dir().DIRECTORY_SEPARATOR.'parsel_save_'.uniqid().'.json';
 
     expect(Parsel::file(fixture('sample.pdf'))->save($out))->toBe($out)
-        ->and(file_get_contents($out))->toContain('"text_items"');
+        ->and(file_get_contents($out))->toContain('"textItems"');
 
     unlink($out);
 });
@@ -98,7 +110,7 @@ it('streams pages lazily from a bytes source', function (): void {
 });
 
 it('skips non-array page entries while streaming', function (): void {
-    $runner = new FakeJsonOutputRunner('{"pages":["bad",{"page":1,"text":"a","text_items":[]}]}');
+    $runner = new FakeJsonOutputRunner('{"pages":["bad",{"page":1,"text":"a","textItems":[]}]}');
     $parse = new PendingParse(Source::fromPath(fixture('sample.pdf')), $runner, binary: 'lit');
 
     expect(iterator_to_array($parse->lazyPages()))->toHaveCount(1);


### PR DESCRIPTION
Fixes #9

## What

Fixes empty `$page->items` and null `fontName`/`fontSize` when parsing real PDFs.

Different distributions of liteparse emit different key formats:
- **npm** (`@llamaindex/liteparse`) outputs camelCase: `textItems`, `fontName`, `fontSize`
- **cargo / pip** builds output snake_case: `text_items`, `font_name`, `font_size`

The PHP DTOs were only reading snake_case keys, so the npm distribution broke. This fix reads camelCase first and falls back to snake_case so both distributions work.

## Changes

- `Page::fromArray()` — `$raw['textItems'] ?? $raw['text_items'] ?? []`
- `TextItem::fromArray()` — camelCase keys with snake_case fallback for `fontName`/`fontSize`
- Updated test fixture to use camelCase keys (matching npm binary output)
- Added tests for snake_case fallback path

## Test plan

- [x] camelCase keys populate `items`, `fontName`, `fontSize` correctly
- [x] snake_case keys (fallback) populate the same fields correctly
- [x] Integration tests pass against real `lit` binary (npm 2.0.0)
- [x] All 104 unit tests pass