### PR TITLE
feat: add Document::page(int $n) to look up a page by number

### DIFF
--- a/src/Data/Document.php
+++ b/src/Data/Document.php
@@ -75,7 +75,20 @@ final readonly class Document
         return count($this->pages);
     }
 
+    /**
+     * @throws PageNotFoundException
+     */
     public function page(int $number): Page
+    {
+        return $this->find($number) ?? throw PageNotFoundException::forNumber($number);
+    }
+
+    public function hasPage(int $number): bool
+    {
+        return $this->find($number) instanceof Page;
+    }
+
+    private function find(int $number): ?Page
     {
         foreach ($this->pages as $page) {
             if ($page->number === $number) {
@@ -83,7 +96,7 @@ final readonly class Document
             }
         }
 
-        throw PageNotFoundException::forNumber($number);
+        return null;
     }
 
     /**

--- a/src/Data/Document.php
+++ b/src/Data/Document.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shipfastlabs\Parsel\Data;
 
+use Shipfastlabs\Parsel\Exceptions\PageNotFoundException;
+
 final readonly class Document
 {
     /**
@@ -71,6 +73,17 @@ final readonly class Document
     public function pageCount(): int
     {
         return count($this->pages);
+    }
+
+    public function page(int $number): Page
+    {
+        foreach ($this->pages as $page) {
+            if ($page->number === $number) {
+                return $page;
+            }
+        }
+
+        throw PageNotFoundException::forNumber($number);
     }
 
     /**

--- a/src/Exceptions/PageNotFoundException.php
+++ b/src/Exceptions/PageNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shipfastlabs\Parsel\Exceptions;
+
+final class PageNotFoundException extends ParselException
+{
+    public static function forNumber(int $number): self
+    {
+        return new self(sprintf('Page %d was not found in the document.', $number));
+    }
+}

--- a/tests/Unit/Dtos/DocumentTest.php
+++ b/tests/Unit/Dtos/DocumentTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Shipfastlabs\Parsel\Data\Document;
+use Shipfastlabs\Parsel\Data\Page;
+use Shipfastlabs\Parsel\Exceptions\PageNotFoundException;
 
 it('maps real liteparse json into a document', function (): void {
     /** @var array<string, mixed> $decoded */
@@ -71,3 +73,22 @@ it('array reshape skips page entries that are not arrays', function (): void {
 
     expect($array['pages'])->toHaveCount(1);
 });
+
+it('returns a page by its 1-based number', function (): void {
+    $doc = Document::fromLiteParseJson([
+        'pages' => [
+            ['page' => 1, 'text' => 'first', 'textItems' => []],
+            ['page' => 2, 'text' => 'second', 'textItems' => []],
+        ],
+    ]);
+
+    expect($doc->page(2))->toBeInstanceOf(Page::class)
+        ->and($doc->page(2)->number)->toBe(2)
+        ->and($doc->page(2)->text)->toBe('second');
+});
+
+it('throws PageNotFoundException when the page number does not exist', function (): void {
+    $doc = Document::fromLiteParseJson(['pages' => [['page' => 1, 'text' => 'a', 'textItems' => []]]]);
+
+    $doc->page(99);
+})->throws(PageNotFoundException::class, 'Page 99 was not found in the document.');

--- a/tests/Unit/Dtos/DocumentTest.php
+++ b/tests/Unit/Dtos/DocumentTest.php
@@ -82,9 +82,11 @@ it('returns a page by its 1-based number', function (): void {
         ],
     ]);
 
-    expect($doc->page(2))->toBeInstanceOf(Page::class)
-        ->and($doc->page(2)->number)->toBe(2)
-        ->and($doc->page(2)->text)->toBe('second');
+    $page = $doc->page(2);
+
+    expect($page)->toBeInstanceOf(Page::class)
+        ->and($page->number)->toBe(2)
+        ->and($page->text)->toBe('second');
 });
 
 it('throws PageNotFoundException when the page number does not exist', function (): void {
@@ -92,3 +94,10 @@ it('throws PageNotFoundException when the page number does not exist', function 
 
     $doc->page(99);
 })->throws(PageNotFoundException::class, 'Page 99 was not found in the document.');
+
+it('reports whether a page number exists', function (): void {
+    $doc = Document::fromLiteParseJson(['pages' => [['page' => 1, 'text' => 'a', 'textItems' => []]]]);
+
+    expect($doc->hasPage(1))->toBeTrue()
+        ->and($doc->hasPage(99))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Adds `Document::page(int $number): Page` — looks up a page by its 1-based page number
- Adds `Document::hasPage(int $number): bool` — non-throwing existence check, so callers can probe without a try/catch
- Throws `PageNotFoundException` (new, extends `ParselException`) when the number doesn't exist in the document
- Gives callers a typed, descriptive exception instead of an `Undefined array key` error from direct array access
- Both lookups share a private `find()` helper; `page()` is annotated with `@throws`

## Usage

```php
$document = Parsel::file('report.pdf')->parse();

if ($document->hasPage(3)) {
    $page = $document->page(3); // returns Page, guaranteed present
}

$document->page(99); // throws PageNotFoundException
```

## Test plan

- [x] Returns correct `Page` instance for a valid page number
- [x] `hasPage()` returns `true` for an existing page and `false` for a missing one
- [x] Throws `PageNotFoundException` with message `"Page 99 was not found in the document."` for missing page
- [x] Lint (pint + rector), PHPStan, and unit suite pass