### PR TITLE
ci: install liteparse and run integration tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,5 +44,11 @@ jobs:
     - name: Install Composer dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
+    - name: Install liteparse
+      run: npm install -g @llamaindex/liteparse
+
     - name: Unit Tests
       run: composer test:unit
+
+    - name: Integration Tests
+      run: composer test:integration

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
             "rector --dry-run"
         ],
         "test:unit": "pest --parallel --coverage --exactly=100 --exclude-group=integration",
+        "test:integration": "pest --group=integration",
         "test:types": "phpstan",
         "test:refactor": "rector --dry-run",
         "test": [


### PR DESCRIPTION
## Problem

Integration tests were never running in CI because the `lit` binary was not installed on GitHub runners. The workflow only ran `composer test:unit` which excludes the `integration` group — so real-binary codepaths (structured document parsing, lazy streaming) were never verified.

This is how the camelCase DTO bug (#9) went undetected: unit tests pass against fixture JSON, but integration tests hit the actual binary output.

## Changes

- `.github/workflows/tests.yml` — add `npm install -g @llamaindex/liteparse` step and an `Integration Tests` step after unit tests
- `composer.json` — add `test:integration` script (`pest --group=integration`)

## Result

All 6 matrix runners (ubuntu/macos/windows × prefer-lowest/prefer-stable) now install `lit` and run integration tests on every push and pull request.

## Test plan

- [x] `composer test:unit` still passes (unchanged)
- [x] `composer test:integration` runs the 3 integration tests against the real binary locally — all pass